### PR TITLE
fixed java.lang.StringIndexOutOfBoundsException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterTypeDescriptor.java
@@ -58,7 +58,7 @@ public class CharacterTypeDescriptor extends AbstractTypeDescriptor<Character> {
 		}
 		if ( String.class.isInstance( value ) ) {
 			final String str = (String) value;
-			if(str.length()==0){
+			if(str.length() == 0){
 				return null;
 			}
 			return str.charAt( 0 );


### PR DESCRIPTION
fixed java.lang.StringIndexOutOfBoundsException: String index out of range: 0 when value string is an empty string(e.g '')